### PR TITLE
Static pipeline

### DIFF
--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -75,8 +75,8 @@ module Index = struct
   let* () = Current.Job.use_pool ~switch job Remote_cache.ssh_pool in
   let* () = Current.Job.start ~level:Mostly_harmless job in
   let* _ =
-    Current.Process.exec ~cancellable:true ~job
-      ( Fpath.to_string state_dir,
+    Current.Process.exec ~cancellable:true ~cwd:state_dir ~job
+      ( "",
         [|
           "rsync";
           "-avzR";

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -94,6 +94,6 @@ module StatCache = Current_cache.Output (Index)
 
 let v ~ssh ~package_name ~statuses : unit Current.t =
   let open Current.Syntax in
-  Current.component "set-status" |>
+  Current.component "set-status for %s" package_name |>
   let> statuses = statuses in
   StatCache.set ssh package_name statuses


### PR DESCRIPTION
The `package_status` has been changed to keep the static information (package names/universes) out of the pipeline. This way the status report remains fully static  